### PR TITLE
fetch yew from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["ywzjackal@163.com <ywzjackal@163.com>"]
 
 [dependencies]
 stdweb = "0.4"
-yew = {git="https://github.com/DenisKolodin/yew.git"}
+yew = "0.5"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SVG Icon Helper for [yew framework](https://github.com/DenisKolodin/yew) 
 
-need yew version: 0.5.0 on master
-
 ## USAGE
 
 ### 1) with remote svg-defs:

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["ywzjackal@163.com <ywzjackal@163.com>"]
 
 [dependencies]
-yew = {git="https://github.com/DenisKolodin/yew.git"}
+yew = "0.5"
 yew_svg = {path="../"}


### PR DESCRIPTION
0.5 has been released, git master is no longer needed.

In fact git now points to 0.6 and in its current state the project is not usable in yew 0.5 projects.